### PR TITLE
Move types `i128` aand `u128` inside namespace `ntlib`.

### DIFF
--- a/benchmarks/isqrt.cpp
+++ b/benchmarks/isqrt.cpp
@@ -47,7 +47,7 @@ BENCHMARK(BM_isqrt_int_binsearch)->Unit(benchmark::kMillisecond);
 
 static void BM_isqrt_int128(benchmark::State &state) {
   for (auto _ : state) {
-    for (i128 n = 1; n < N; ++n) {
+    for (ntlib::i128 n = 1; n < N; ++n) {
       benchmark::DoNotOptimize(ntlib::isqrt(n));
     }
   }

--- a/benchmarks/prime_test.cpp
+++ b/benchmarks/prime_test.cpp
@@ -56,8 +56,9 @@ BENCHMARK(BM_is_prime_miller_selfridge_rabin)
 
 static void BM_is_prime_baillie_psw(benchmark::State &state) {
   for (auto _ : state) {
-    for (u128 i = state.range(0); i <= state.range(0) + NUM_TESTS; ++i) {
-      benchmark::DoNotOptimize(ntlib::is_prime_baillie_psw<u128, i128>(i));
+    for (ntlib::u128 i = state.range(0); i <= state.range(0) + NUM_TESTS; ++i) {
+      benchmark::DoNotOptimize(
+          ntlib::is_prime_baillie_psw<ntlib::u128, ntlib::i128>(i));
     }
   }
 }

--- a/include/int128.hpp
+++ b/include/int128.hpp
@@ -1,10 +1,18 @@
 #pragma once
 
+#include <type_traits>
+
+namespace ntlib {
+
 // Wrapper around 128 bit integers as these are non-standard.
 using i128 = __int128;
 using u128 = unsigned __int128;
 
-namespace ntlib {
+/**
+ * Concept for 128 bit integers.
+ */
+template<typename T>
+concept Int128 = std::is_same_v<T, i128> || std::is_same_v<T, u128>;
 
 /**
  * Specialization for `get_multiplicative_neutral()`.
@@ -12,10 +20,9 @@ namespace ntlib {
  * @param _ Element of the type.
  * @return The multiplicative neutral element (`1`).
  */
-template<typename T>
+template<Int128 T>
 [[nodiscard]] constexpr
-T get_multiplicative_neutral(T)
-    requires(std::is_same_v<T, i128> || std::is_same_v<T, u128>) {
+T get_multiplicative_neutral(T) {
   return T{1};
 }
 

--- a/test/base.cpp
+++ b/test/base.cpp
@@ -13,14 +13,15 @@
 #include "mod_int.hpp"
 #include "prime_generation.hpp"
 
-static constexpr int min_int = std::numeric_limits<int>::min();
-static constexpr int max_int = std::numeric_limits<int>::max();
+using std::numeric_limits;
+static constexpr int min_int = numeric_limits<int>::min();
+static constexpr int max_int = numeric_limits<int>::max();
 static constexpr unsigned int max_uint =
-    std::numeric_limits<unsigned int>::max();
-static constexpr int64_t max_int64 = std::numeric_limits<int64_t>::max();
-static constexpr uint64_t max_uint64 = std::numeric_limits<uint64_t>::max();
-static constexpr i128 max_int128 = (i128{1} << 126) - 1 + (i128{1} << 126);
-static constexpr u128 max_uint128 = (u128{1} << 127) - 1 + (u128{1} << 127);
+    numeric_limits<unsigned int>::max();
+static constexpr int64_t max_int64 = numeric_limits<int64_t>::max();
+static constexpr uint64_t max_uint64 = numeric_limits<uint64_t>::max();
+static constexpr ntlib::i128 max_int128 = numeric_limits<ntlib::i128>::max();
+static constexpr ntlib::u128 max_uint128 = numeric_limits<ntlib::u128>::max();
 
 TEST(SmallPrimes, ListContainsOnlyPrimes) {
   const auto sieve = ntlib::prime_sieve(ntlib::SMALL_PRIMES_BIGGEST);
@@ -275,8 +276,8 @@ TEST(IntegerLog2, Unsigned) {
 }
 
 TEST(IntegerLog2, NoBuiltin) {
-  for (u128 i = 1; i < 1'000'000; ++i) {
-    u128 cl2 = ntlib::ilog2(i);
+  for (ntlib::u128 i = 1; i < 1'000'000; ++i) {
+    ntlib::u128 cl2 = ntlib::ilog2(i);
     EXPECT_LE(1 << cl2, i);
     EXPECT_GT(1 << (cl2 + 1), i);
   }
@@ -298,8 +299,8 @@ TEST(IntegerSquareRoot, Integral) {
 }
 
 TEST(IntegerSquareRoot, NoBuiltin) {
-  for (u128 i = 0; i <= 1'000'000; ++i) {
-    u128 root = ntlib::isqrt(i);
+  for (ntlib::u128 i = 0; i <= 1'000'000; ++i) {
+    ntlib::u128 root = ntlib::isqrt(i);
     EXPECT_LE(root * root, i);
     EXPECT_GT((root + 1) * (root + 1), i);
   }
@@ -312,14 +313,14 @@ TEST(IntegerSquareRoot, CornerCases) {
   EXPECT_EQ(ntlib::isqrt(max_int64), 3'037'000'499LL);
   EXPECT_EQ(ntlib::isqrt(max_uint64), 4'294'967'295LL);
 
-  i128 iroot128_ntlib = ntlib::isqrt(max_int128);
-  i128 iroot128_expected =
-      i128(2) * 2 * 3 * 3 * 3 * 991 * 283'183 * 430'368'163;
+  ntlib::i128 iroot128_ntlib = ntlib::isqrt(max_int128);
+  ntlib::i128 iroot128_expected =
+      ntlib::i128(2) * 2 * 3 * 3 * 3 * 991 * 283'183 * 430'368'163;
   EXPECT_EQ(iroot128_ntlib, iroot128_expected);
 
-  u128 uroot128_ntlib = ntlib::isqrt(max_uint128);
-  u128 uroot128_expected =
-      u128(3) * 5 * 17 * 257 * 641 * 65537 * 6'700'417;
+  ntlib::u128 uroot128_ntlib = ntlib::isqrt(max_uint128);
+  ntlib::u128 uroot128_expected =
+      ntlib::u128(3) * 5 * 17 * 257 * 641 * 65537 * 6'700'417;
   EXPECT_EQ(uroot128_ntlib, uroot128_expected);
 }
 

--- a/test/int128.cpp
+++ b/test/int128.cpp
@@ -3,13 +3,13 @@
 #include "int128.hpp"
 
 TEST(MultiplicativeNeutral, Signed) {
-  auto neutral = ntlib::get_multiplicative_neutral(i128{-5});
-  EXPECT_TRUE((std::is_same_v<decltype(neutral), i128>));
+  auto neutral = ntlib::get_multiplicative_neutral(ntlib::i128{-5});
+  EXPECT_TRUE((std::is_same_v<decltype(neutral), ntlib::i128>));
   EXPECT_EQ(neutral, 1);
 }
 
 TEST(MultiplicativeNeutral, Unsigned) {
-  auto neutral = ntlib::get_multiplicative_neutral(u128{5});
-  EXPECT_TRUE((std::is_same_v<decltype(neutral), u128>));
+  auto neutral = ntlib::get_multiplicative_neutral(ntlib::u128{5});
+  EXPECT_TRUE((std::is_same_v<decltype(neutral), ntlib::u128>));
   EXPECT_EQ(neutral, 1);
 }

--- a/test/pell_equation.cpp
+++ b/test/pell_equation.cpp
@@ -23,8 +23,8 @@ TEST(MinPellSolutions, SmallValues) {
 }
 
 TEST(MinPellSolutions, BiggerValues) {
-  const u128 N = 1'000;
-  for (u128 d = 2; d <= N; ++d) {
+  const ntlib::u128 N = 1'000;
+  for (ntlib::u128 d = 2; d <= N; ++d) {
     if (ntlib::is_square(d)) continue;
     const auto [x, y] = ntlib::min_pell_solution(d);
     EXPECT_EQ(x * x - d * y * y, 1);
@@ -32,16 +32,16 @@ TEST(MinPellSolutions, BiggerValues) {
 }
 
 TEST(NextPellSolution, SmallValues) {
-  const u128 N = 100;
-  const u128 M = 10;
-  for (u128 d = 2; d <= N; ++d) {
+  const ntlib::u128 N = 100;
+  const ntlib::u128 M = 10;
+  for (ntlib::u128 d = 2; d <= N; ++d) {
     if (ntlib::is_square(d)) continue;
     const auto s0 = ntlib::min_pell_solution(d);
     const auto [x0, y0] = s0;
     EXPECT_EQ(x0 * x0 - d * y0 * y0, 1);
 
     auto last = s0;
-    for (u128 i = 0; i < M; ++i) {
+    for (ntlib::u128 i = 0; i < M; ++i) {
       const auto si = ntlib::next_pell_solution(d, s0, last);
       const auto [xi, yi] = si;
       EXPECT_EQ(xi * xi - d * yi * yi, 1);

--- a/test/prime_test.cpp
+++ b/test/prime_test.cpp
@@ -13,7 +13,7 @@ static constexpr uint64_t N = 1'000'000;
 static const auto SIEVE = ntlib::prime_sieve(N);
 
 // Large composites.
-static constexpr auto COMPOSITES = std::to_array<u128>({
+static constexpr auto COMPOSITES = std::to_array<ntlib::u128>({
     1'000'000'007LL * 1'000'000'007LL,
     4'120'038'565'055'551LL,
     2LL * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2,
@@ -21,7 +21,7 @@ static constexpr auto COMPOSITES = std::to_array<u128>({
 });
 
 // Large primes.
-static constexpr auto PRIMES = std::to_array<u128>({
+static constexpr auto PRIMES = std::to_array<ntlib::u128>({
     1'000'000'007,
     952'016'363'681'739'749LL,
     301'697'296'732'166'057LL
@@ -152,12 +152,12 @@ TEST(BailliePSW, NegativeValues) {
 
 TEST(BailliePSW, LargeComposites) {
   for (auto c : COMPOSITES) {
-    EXPECT_FALSE((ntlib::is_prime<u128, i128>(c)));
+    EXPECT_FALSE((ntlib::is_prime<ntlib::u128, ntlib::i128>(c)));
   }
 }
 
 TEST(BailliePSW, LargePrimes) {
   for (auto p : PRIMES) {
-    EXPECT_TRUE((ntlib::is_prime<u128, i128>(p)));
+    EXPECT_TRUE((ntlib::is_prime<ntlib::u128, ntlib::i128>(p)));
   }
 }


### PR DESCRIPTION
fixes #38 